### PR TITLE
Support multiple deployments of Backname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
     ports:
       - "53:53/udp"
     environment:
-      - ZONE
-      - WEBSITE_WWW_CNAME
+      # The domain name under which Backname is running (example: backname.io)
+      - ZONE=example.com
+      # The public IPv4 address of the server hosting Backname or two comma-separated addresses
+      - NAMESERVER_A=127.0.0.1
+      # Optional: Serve a website at the root of the zone + the www subdomain by specifying their A and/or AAAA records
       - WEBSITE_A
       - WEBSITE_AAAA
-      - NAMESERVER_PUBLIC_IPV4


### PR DESCRIPTION
Until now, Backname could only be deployed on one server at once, which wasn't spec compliant. WIth this, spec compliance is finally achieved, as production Backname will point to nameservers at `alpha.backname.io` and `omega.backname.io`.